### PR TITLE
Update stack and python version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,8 +16,8 @@ rm -fr $CACHE_DIR
 mkdir -p $CACHE_DIR
 
 # Versions.
-PYTHON_VERSION="python-3.4.3"
-PYTHON_STACK="cedar-14"
+PYTHON_VERSION="python-3.6.10"
+PYTHON_STACK="heroku-18"
 NGINX_VERSION="nginx-1.7.2"
 PCRE_VERSION='pcre-8.36'
 source $BIN_DIR/utils


### PR DESCRIPTION
This will fix the broken build in staging:

![Screen Shot 2020-02-05 at 13 19 42](https://user-images.githubusercontent.com/6595551/73862554-76a50880-481d-11ea-8a74-a253128c1078.png) 

Also [cedar-14 is no longer supported](https://help.heroku.com/SMQ1J712/cedar-14-end-of-life-faq)
